### PR TITLE
Fix function comments based on best practices from Effective Go

### DIFF
--- a/app_main.go
+++ b/app_main.go
@@ -77,7 +77,7 @@ func CommandLineTool2(config AppConfig, main_task MainTask, background_tasks ...
 ////////////////////////////////////////////////////////////////////////////////
 // RPC SERVER STARTUP
 
-// RPCServer runs a set of RPC Services, you generally call this from the main()
+// RPCServerTool runs a set of RPC Services, you generally call this from the main()
 // function and ensure to import rpc/server and rpc/discovery modules anonymously
 // into your application as well as all your RPC services
 func RPCServerTool(config AppConfig, background_tasks ...BackgroundTask) int {

--- a/flags.go
+++ b/flags.go
@@ -171,7 +171,7 @@ func (this *Flags) FlagFloat64(name string, value float64, usage string) *float6
 ////////////////////////////////////////////////////////////////////////////////
 // GET FLAGS
 
-// Get boolean value for a flag, and a boolean which indicates if the flag
+// GetBool gets boolean value for a flag, and a boolean which indicates if the flag
 // was set
 func (this *Flags) GetBool(name string) (bool, bool) {
 	value := this.flagset.Lookup(name)
@@ -181,7 +181,7 @@ func (this *Flags) GetBool(name string) (bool, bool) {
 	return value.Value.(flag.Getter).Get().(bool), this.HasFlag(name)
 }
 
-// Get string value for a flag, and a boolean which indicates if the flag
+// GetString gets string value for a flag, and a boolean which indicates if the flag
 // was set
 func (this *Flags) GetString(name string) (string, bool) {
 	value := this.flagset.Lookup(name)
@@ -191,7 +191,7 @@ func (this *Flags) GetString(name string) (string, bool) {
 	return value.Value.(flag.Getter).Get().(string), this.HasFlag(name)
 }
 
-// Get duration value for a flag, and a boolean which indicates if the flag
+// GetDuration gets duration value for a flag, and a boolean which indicates if the flag
 // was set
 func (this *Flags) GetDuration(name string) (time.Duration, bool) {
 	value := this.flagset.Lookup(name)
@@ -201,7 +201,7 @@ func (this *Flags) GetDuration(name string) (time.Duration, bool) {
 	return value.Value.(flag.Getter).Get().(time.Duration), this.HasFlag(name)
 }
 
-// Get integer value for a flag, and a boolean which indicates if the flag
+// GetInt gets integer value for a flag, and a boolean which indicates if the flag
 // was set
 func (this *Flags) GetInt(name string) (int, bool) {
 	value := this.flagset.Lookup(name)
@@ -211,7 +211,7 @@ func (this *Flags) GetInt(name string) (int, bool) {
 	return value.Value.(flag.Getter).Get().(int), this.HasFlag(name)
 }
 
-// Get unsigned integer value for a flag, and a boolean which indicates if
+// GetUint gets unsigned integer value for a flag, and a boolean which indicates if
 // the flag was set
 func (this *Flags) GetUint(name string) (uint, bool) {
 	value := this.flagset.Lookup(name)
@@ -221,7 +221,7 @@ func (this *Flags) GetUint(name string) (uint, bool) {
 	return value.Value.(flag.Getter).Get().(uint), this.HasFlag(name)
 }
 
-// Get unsigned integer value for a flag, and a boolean which indicates if
+// GetUint16 gets unsigned integer value for a flag, and a boolean which indicates if
 // the flag was set
 func (this *Flags) GetUint16(name string) (uint16, bool) {
 	value := this.flagset.Lookup(name)
@@ -232,7 +232,7 @@ func (this *Flags) GetUint16(name string) (uint16, bool) {
 	return uint16(uint_value), this.HasFlag(name)
 }
 
-// Get float64 value for a flag, and a boolean which indicates if
+// GetFloat64 gets float64 value for a flag, and a boolean which indicates if
 // the flag was set
 func (this *Flags) GetFloat64(name string) (float64, bool) {
 	value := this.flagset.Lookup(name)

--- a/sys/logger/logger.go
+++ b/sys/logger/logger.go
@@ -154,7 +154,7 @@ func (this *driver) Close() error {
 ////////////////////////////////////////////////////////////////////////////////
 // LOGGING INTERFACE
 
-// Get logging level
+// Level gets logging level
 func (this *driver) Level() Level {
 	return this.level
 }


### PR DESCRIPTION
Hi, we updated some exported function comments based on best practices from [Effective Go](https://golang.org/doc/effective_go.html). It’s admittedly a relatively minor fix up. Does this help you?